### PR TITLE
Implementar conmutación L3 simple

### DIFF
--- a/src/simple_router.py
+++ b/src/simple_router.py
@@ -23,13 +23,14 @@ from ryu.lib.packet import ethernet
 from ryu.lib.packet import ether_types
 
 
-class SimpleSwitch13(app_manager.RyuApp):
+class SimpleRouter(app_manager.RyuApp):
     OFP_VERSIONS = [ofproto_v1_3.OFP_VERSION]
 
     def __init__(self, *args, **kwargs):
-        super(SimpleSwitch13, self).__init__(*args, **kwargs)
+        super(SimpleRouter, self).__init__(*args, **kwargs)
         self.mac_to_port = {}
 
+    # pylint: disable=no-member
     @set_ev_cls(ofp_event.EventOFPSwitchFeatures, CONFIG_DISPATCHER)
     def switch_features_handler(self, ev):
         datapath = ev.msg.datapath
@@ -63,6 +64,7 @@ class SimpleSwitch13(app_manager.RyuApp):
                                     match=match, instructions=inst)
         datapath.send_msg(mod)
 
+    # pylint: disable=no-member
     @set_ev_cls(ofp_event.EventOFPPacketIn, MAIN_DISPATCHER)
     def _packet_in_handler(self, ev):
         # If you hit this you might want to increase

--- a/src/simple_router.py
+++ b/src/simple_router.py
@@ -20,7 +20,7 @@ from ryu.controller.handler import set_ev_cls
 from ryu.ofproto import ofproto_v1_3
 from ryu.lib.packet import packet
 from ryu.lib.packet import ethernet
-from ryu.lib.packet.ether_types import ETH_TYPE_LLDP, ETH_TYPE_IPV6
+from ryu.lib.packet import ether_types as etypes
 
 
 class SimpleRouter(app_manager.RyuApp):
@@ -81,7 +81,7 @@ class SimpleRouter(app_manager.RyuApp):
         pkt = packet.Packet(msg.data)
         eth = pkt.get_protocols(ethernet.ethernet)[0]
 
-        if eth.ethertype in [ ETH_TYPE_LLDP, ETH_TYPE_IPV6 ]:
+        if eth.ethertype in [ etypes.ETH_TYPE_LLDP, etypes.ETH_TYPE_IPV6 ]:
             # ignore lldp packet
             return
         dst = eth.dst

--- a/src/simple_router.py
+++ b/src/simple_router.py
@@ -20,7 +20,7 @@ from ryu.controller.handler import set_ev_cls
 from ryu.ofproto import ofproto_v1_3
 from ryu.lib.packet import packet
 from ryu.lib.packet import ethernet
-from ryu.lib.packet import ether_types
+from ryu.lib.packet.ether_types import ETH_TYPE_LLDP, ETH_TYPE_IPV6
 
 
 class SimpleRouter(app_manager.RyuApp):
@@ -81,7 +81,7 @@ class SimpleRouter(app_manager.RyuApp):
         pkt = packet.Packet(msg.data)
         eth = pkt.get_protocols(ethernet.ethernet)[0]
 
-        if eth.ethertype == ether_types.ETH_TYPE_LLDP:
+        if eth.ethertype in [ ETH_TYPE_LLDP, ETH_TYPE_IPV6 ]:
             # ignore lldp packet
             return
         dst = eth.dst

--- a/src/simple_router.py
+++ b/src/simple_router.py
@@ -136,11 +136,12 @@ class SimpleRouter(app_manager.RyuApp):
         elif ip:
             self.logger.info(f' IPv4 {ip.src} to {ip.dst} {ip.ttl}')
 
-        if not out_port:
-            self.logger.info(' no match, flooding')
-            out_port = ofproto.OFPP_FLOOD
-
-        actions = [parser.OFPActionOutput(out_port)]
+        # Fallback
+        if not actions:
+            if not out_port:
+                self.logger.info(' no match, flooding')
+                out_port = ofproto.OFPP_FLOOD
+            actions += [parser.OFPActionOutput(out_port)]
 
         # install a flow to avoid packet_in next time
         if out_port != ofproto.OFPP_FLOOD:


### PR DESCRIPTION
Está resuelto el problema de la conmutación L3 **básica**.

La nueva app tiene datos 'constantes' duplicados de `scenario.py` que habría que unificar.

El ARP **no** está implementado, y el DHCP menos, así que los hosts **tienen** que saber la MAC del router. Esto implica que las MACs del router tienen que ser conocida (ver #14)

La tabla de enrutamiento se obtiene de forma precaria de la estructura `INTERFACES`, e indica las interfaces ahí definidas que hay que tomar para llegar al destino. La app tiene que identificar qué puertos del Datapath corresponden a estas interfaces definidas como datos, y enviar los paquetes por esos puertos con las MACs correspondientes. Para enviar a la MAC correcta, la app crea una tabla ARP básica a partir de la misma estructura `INTERFACES`.

El ping funciona.

![image](https://github.com/user-attachments/assets/cac74838-3313-4d94-a061-bddc9ea5e27c)
