### PR TITLE
Deshabilitar ARP estático

### DIFF
--- a/src/scenario.py
+++ b/src/scenario.py
@@ -34,12 +34,12 @@ INTERFACES = {
 # Define each host through its (hopefully) only interface
 HOSTS = [ ifaces[0] for hname, ifaces in INTERFACES.items() if hname[0]=='h' ]
 
-# From the interfaces, define the ARP table
-# ARP_DICT = {i['ip']: i['mac'] for dev in INTERFACES.values() for i in dev}
-ARP_ENTRIES = [
-        (dev['ip'].split('/')[0], dev['mac']) # IP address before the '/'
-        for node in INTERFACES.values() for dev in node
-    ]
+# # From the interfaces, define the ARP table
+# # ARP_DICT = {i['ip']: i['mac'] for dev in INTERFACES.values() for i in dev}
+# ARP_ENTRIES = [
+#         (dev['ip'].split('/')[0], dev['mac']) # IP address before the '/'
+#         for node in INTERFACES.values() for dev in node
+#     ]
 
 
 class StarTopo(Topo):
@@ -58,13 +58,13 @@ class StarTopo(Topo):
             host = self.addHost(**opts)
             self.addLink(host, switch)
 
-class ArpHost(Host):
-    "Host that's initialized with an ARP cache"
-
-    def config(self, arpEntries={}, **params):
-        r = super().config(**params)
-        for ip, mac in arpEntries:  self.setARP(ip, mac)
-        return r
+# class ArpHost(Host):
+#     "Host that's initialized with an ARP cache"
+#
+#     def config(self, arpEntries={}, **params):
+#         r = super().config(**params)
+#         for ip, mac in arpEntries:  self.setARP(ip, mac)
+#         return r
 
 
 def int2mac(mac_int: int):

--- a/src/scenario.py
+++ b/src/scenario.py
@@ -101,7 +101,6 @@ def simpleTestCLI():
 
     net = Mininet(
             topo       = StarTopo(HOSTS),
-            host       = partial(ArpHost, arpEntries=ARP_ENTRIES),
             controller = partial(RemoteController, ip='127.0.0.1'),
             switch     = partial(OVSSwitch, protocols='OpenFlow13')
         )


### PR DESCRIPTION
Deshabilitar el ARP estático en los hosts es fácil. Efectivamente, las tablas ARP empiezan vacías, pero si se rellenan a mano todo lo demás sigue funcionando.

![image](https://github.com/user-attachments/assets/f23e6a4e-a0c6-4caf-a357-5aa2bc52957e)
